### PR TITLE
fixed msys2 vim crash when cwd is /

### DIFF
--- a/autoload/djangoplus/detect.vim
+++ b/autoload/djangoplus/detect.vim
@@ -31,7 +31,7 @@ endfunction
 
 " Test a directory for a management script>
 function! s:is_django_project(dirname)
-  if filereadable(a:dirname.'/manage.py')
+  if a:dirname != '/' && filereadable(a:dirname.'/manage.py')
     let $_DJANGOPLUS_MANAGEMENT = a:dirname.'/manage.py'
     return 1
   endif


### PR DESCRIPTION
in msys2, when cwd is /, vim will crash with checking `filereadable('//manage.py')`