### PR TITLE
Don't register filetype detection more than once

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -1,4 +1,5 @@
-augroup filetypedetect
+augroup djangoplusfiletypedetect
   " Since templates can be anything, check any file.
+  autocmd!
   autocmd BufRead,BufNewFile * call djangoplus#detect#filetype(expand('<afile>:p'))
 augroup END


### PR DESCRIPTION
This adds a command to avoid redefining autocmd more than once in a vim session.

Every time vim sets filetype for a new buffer, vim will re-run ftdetect.vim. The augroup in django-plus.vim's ftdetect.vim file didn't clear any of the existing commands in its augroup, so the autocmd will get registered multiple times. Indeed, this can be verified by running `:autocmd filetypedetect` to see that this command has been registered multiple times:

    filetypedetect BufReadPost
        *        call djangoplus#detect#filetype(expand('<afile>:p'))
        *        call djangoplus#detect#filetype(expand('<afile>:p'))
        *        call djangoplus#detect#filetype(expand('<afile>:p'))
        [repeat 100 times]

I don't have measurements, but I can see a noticeable effect on the delay when opening new buffers in long running vim session with lots of open files.