### PR TITLE
Exclude QuickFix from dectect#filetype function

### DIFF
--- a/autoload/djangoplus/detect.vim
+++ b/autoload/djangoplus/detect.vim
@@ -174,7 +174,7 @@ endfunction
 
 " Detect Django related files
 function! djangoplus#detect#filetype(filename) abort
-  if empty(a:filename)
+  if empty(a:filename) || &l:filetype == 'qf'
     return
   endif
 


### PR DESCRIPTION
Fixes conflict specifically with [vim-qf](https://github.com/romainl/vim-qf)'s QuickFix functions. QuickFix, in general, should be skipped with this function
 Issue could effect other Plugins in similar situations, but this commit only solves QuickFix.

### Specs:
* Vim: Vim 9 (64bit)
* OS: Windows 10 & Pop!_OS/Ubuntu


### How to recreate
* Install both [vim-qf](https://github.com/romainl/vim-qf) & django-plug
* Goto any Django Project's view.py
* `:copen` + `:cclose` + `:copen` + `:cclose`
  * Open/Close 2 or more times


### Result:
```
Error detected while processing FileType Autocommands for "*"..function <SNR>7_LoadFTPlugin
```
* Note: `{x}_LoadFTPlugin` **x** changes based on whatever pid `vim{v}\ftplugin.vim` is in `:scriptnames` 
* Offending command in ftplugin.vim is: `legacy exe b:undo_ftplugin`

With tinkering, using `:make`, the error message [below] also shows up
```
Error detected while processig QuickFixCmdPost Autocommands for "make"..function qf#OpenQuickfix[17]..fileFileType Autocommands for "*"..function <SNR>6_LoadFTPlugin:
Line: 3:
E184: No such user-defined command: Filter
```

### Theory:
```
# :help undo_ftplugin 
When the user does ":setfiletype xyz" the effect of the previous filetype
should be undone.
```
When setting the filetype of QuickFix to `qf` **again**, it undoes all vim-qf's functions which causes vim-qf to crash. 
Seeing most Plugins are designed to define functions **one** time, Django-Plus should avoid inadvertently removing them; especially with QuickFix which is a special case

---

### Notes of behavior
```vim
function! djangoplus#detect#filetype(filename) abort

  " Passed with: djangoplus#detect#filetype(expand('<afile>:p')
  echom 'filename ' . a:filename

  " expanded inside the function
  echom 'expand path ' . expand('%:p')

  " filetype Output 
  echom 'filetype &l ' . &l:filetype

  " ... more stuff

endfunction
```

##### 1) Opening `views.py`
```
filename            /path/to/project/app1/views.py
expand path         /path/to/project/app1/views.py
filetype &l         
```

##### 2) Opening `QuickFix`
```
filename            /path/to/project/quickfix
expand path         
filetype &l         qf
```

### Point:
This illustrates why the original `empty(a:filename)` isn't catching the QuickFix.

---
Sorry for the Duplicate :(